### PR TITLE
Move db files to /db/data

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ snapcraft pack
 sudo snap install ./mongodb*.charm --devmode
 ```
 
+### Manually Connect System Files
+```bash
+sudo snap connect mongodb:db-data :system-files
+```
+
 ## License
 The Percona MongoDB Snap is free software, distributed under the Apache
 Software License, version 2.0. See

--- a/snap/local/start_mongod.sh
+++ b/snap/local/start_mongod.sh
@@ -8,6 +8,4 @@ if [ ! -f "${CONFIG_FILE}" ]; then
 	mkdir -p /db/data
 fi
 
-echo whoami > $CONFIG_FILE/whoami
-
 $SNAP/usr/bin/mongod --config $CONFIG_FILE "$@"

--- a/snap/local/start_mongod.sh
+++ b/snap/local/start_mongod.sh
@@ -5,7 +5,9 @@ if [ ! -f "${CONFIG_FILE}" ]; then
         echo "configuration file does not exist."
         echo "copying default config to ${CONFIG_FILE}"
         cp -r $SNAP/etc/mongod.conf $SNAP_COMMON
-	mkdir -p $SNAP_COMMON/db
+	mkdir -p /db/data
 fi
+
+echo whoami > $CONFIG_FILE/whoami
 
 $SNAP/usr/bin/mongod --config $CONFIG_FILE "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,12 @@ layout:
   /etc/mongod.conf:
     symlink: $SNAP_COMMON/mongod.conf
 
+plugs:
+  db-data:
+    interface: system-files
+    write:
+      - /db/data
+
 package-repositories:
   - type: apt
     components: [main]
@@ -39,6 +45,7 @@ apps:
     plugs:
       - network
       - network-bind
+      - db-data
   mongodump:
     command: usr/bin/mongodump
   mongoexport:
@@ -65,7 +72,7 @@ parts:
       craftctl default
       sed -i "s/fork: true/fork: false/g" $CRAFT_STAGE/etc/mongod.conf
       sed -i "s:/var/log/mongodb/mongod.log:/var/snap/mongodb/current/mongod.log:g" $CRAFT_STAGE/etc/mongod.conf
-      sed -i "s:/var/lib/mongodb:/var/snap/mongodb/current/db:g" $CRAFT_STAGE/etc/mongod.conf
+      sed -i "s:/var/lib/mongodb:/db/data:g" $CRAFT_STAGE/etc/mongod.conf
       sed -i "s:/var/run/mongod.pid:/var/snap/mongodb/current/mongod.pid:g" $CRAFT_STAGE/etc/mongod.conf
   wrapper:
     plugin: dump


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
Data is written to `$SNAP_DATA` which not ideal for access by other snaps and charms.

* **What is the new behavior (if this is a feature change)?**
This PR adds a plug for the `system-files` interface that allows the snap to write to `/db/data`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Consumers of the snap will need to update their applications for the new data directory as well as create a manual connection.

* **Other information**:
[snapcraft system-files interface](https://snapcraft.io/docs/system-files-interface)
[snapcraft connections](https://snapcraft.io/docs/interface-management#heading--auto-connections)
