### PR TITLE
Drop privileges to snap_daemon user

### DIFF
--- a/snap/local/start_mongod.sh
+++ b/snap/local/start_mongod.sh
@@ -8,9 +8,11 @@ if [ ! -f "${CONFIG_FILE}" ]; then
 	mkdir -p $SNAP_COMMON/db
 	touch $SNAP_DATA/mongod.log
 
+	# Change ownership of snap directories to allow snap_daemon to read/write
         chown -R snap_daemon:root $SNAP_DATA
         chown -R snap_daemon:root $SNAP_COMMON
 fi
 
+# For security measures, daemons should not be run as sudo. Execute mongod as the non-sudo user: snap-daemon.
 $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
   --regid snap_daemon -- $SNAP/usr/bin/mongod --config $CONFIG_FILE "$@"

--- a/snap/local/start_mongod.sh
+++ b/snap/local/start_mongod.sh
@@ -6,12 +6,10 @@ if [ ! -f "${CONFIG_FILE}" ]; then
         echo "copying default config to ${CONFIG_FILE}"
         cp -r $SNAP/etc/mongod.conf $SNAP_COMMON
 	mkdir -p $SNAP_COMMON/db
+	touch $SNAP_DATA/mongod.log
 
-        chmod 770 $CONFIG_FILE
-        chown snap_daemon:root $CONFIG_FILE
-        chmod 770 $SNAP_COMMON/db
-        chown snap_daemon:root $SNAP_COMMON/db
-
+        chown -R snap_daemon:root $SNAP_DATA
+        chown -R snap_daemon:root $SNAP_COMMON
 fi
 
 $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \

--- a/snap/local/start_mongod.sh
+++ b/snap/local/start_mongod.sh
@@ -6,6 +6,13 @@ if [ ! -f "${CONFIG_FILE}" ]; then
         echo "copying default config to ${CONFIG_FILE}"
         cp -r $SNAP/etc/mongod.conf $SNAP_COMMON
 	mkdir -p $SNAP_COMMON/db
+
+        chmod 770 $CONFIG_FILE
+        chown snap_daemon:root $CONFIG_FILE
+        chmod 770 $SNAP_COMMON/db
+        chown snap_daemon:root $SNAP_COMMON/db
+
 fi
 
-$SNAP/usr/bin/mongod --config $CONFIG_FILE "$@"
+$SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
+  --regid snap_daemon -- $SNAP/usr/bin/mongod --config $CONFIG_FILE "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,6 +64,7 @@ parts:
     plugin: nil
     stage-packages:
       - percona-server-mongodb
+      - util-linux
     override-stage: |
       craftctl default
       sed -i "s/fork: true/fork: false/g" $CRAFT_STAGE/etc/mongod.conf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,9 @@ description: |
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 
+system-usernames:
+  snap_daemon: shared
+
 layout:
   /etc/mongod.conf:
     symlink: $SNAP_COMMON/mongod.conf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,7 +69,7 @@ parts:
       craftctl default
       sed -i "s/fork: true/fork: false/g" $CRAFT_STAGE/etc/mongod.conf
       sed -i "s:/var/log/mongodb/mongod.log:/var/snap/mongodb/current/mongod.log:g" $CRAFT_STAGE/etc/mongod.conf
-      sed -i "s:/var/lib/mongodb:/var/snap/mongodb/current/db:g" $CRAFT_STAGE/etc/mongod.conf
+      sed -i "s:/var/lib/mongodb:/var/snap/mongodb/common/db:g" $CRAFT_STAGE/etc/mongod.conf
       sed -i "s:/var/run/mongod.pid:/var/snap/mongodb/current/mongod.pid:g" $CRAFT_STAGE/etc/mongod.conf
   wrapper:
     plugin: dump


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)
mongod is run as `root` in the snap

* **What is the new behavior (if this is a feature change)?**
mongod is run as the `snap_daemon` user

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope.

* **Other information**:
[mongo docs for non-root users](https://www.mongodb.com/developer/products/mongodb/non-root-user-mongod-process/)
[snapcraft system-usernames docs](https://snapcraft.io/docs/system-usernames)
