### PR TITLE
Fix branch filter for on_push

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -1,10 +1,8 @@
 on:
   push:
     branches:
-      - '*.*/*'
+      - '[0-9]/[a-z]+'
   workflow_dispatch:
-    branches:
-      - '*.*/*'
 
 jobs:
   publish:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
`on_push` does not result in publishing because of how the branch filter was set up.

* **What is the new behavior (if this is a feature change)?**
A new branch filter is provided that follows the new branch naming convention.  The snap will publish on an `on_push` event.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
None.
