### PR TITLE
mongodb exporter restarts on failure

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,6 +81,8 @@ apps:
     daemon: simple
     # wrapper is used to run mongodb-exporter as snap_daemon user and pass the URI via `snapctl`.
     command: start-mongodb-exporter.sh
+    restart-condition: always
+    restart-delay: 20s
     plugs:
       - network
       - network-bind


### PR DESCRIPTION
## Problem
when mongodb exporter fails it doesn't attempt to try again

## Context 
in the mongodb charm it would be best to start mongodb-exporter on all units - however we must wait for the monitor user to be created. In the charm it would be great to start mongodb exporter on all units and have it keep retrying until the user is created

## Solution 
add restart arg to snapcraft

## Testing 
Tested by installing in the charm and running `curl http://10.158.125.225:9216/metrics | grep mongo`