### PR TITLE
add slot for graphana to read logs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,6 +51,8 @@ slots:
     source:
       read:
         - $SNAP_COMMON/var/log/mongod
+        - $SNAP_COMMON/var/log/mongos
+        - $SNAP_COMMON/var/log/pbm
 
 apps:
   mongo:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,13 @@ package-repositories:
     key-id: 4D1BB29D63D98E422B2113B19334A25F8507EFA5
     url: http://repo.percona.com/pbm/apt
 
+slots:
+  logs:
+    interface: content
+    source:
+      read:
+        - $SNAP_COMMON/var/log/mongod
+
 apps:
   mongo:
     command: drop_priv.sh mongo


### PR DESCRIPTION
For logs to work in Obs on the charm, the mongo snap also needs to have a slot where the logs are stored. The logs slot is a shared space between snaps, so the grafana agent snap can read into your workload snap where the logs are