### PR TITLE
write file once to snap data

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -23,12 +23,14 @@ if [  -n "${PBM_MONGODB_URI}"  ] && [ ! -f "${PBM_CONFIG_FILE}" ]; then
     # if the URI is incorrect then the config file will be ignored and it is necessary to try again
     # with a correct uri.
     if "$SNAP/usr/bin/pbm" config --file "${PBM_CONFIG_FILE}"; then
-        # SNAP_DATA is not writable by root - so we must switch to `snap_daemon` user. 
+        # SNAP_DATA is not writable by root - so we must switch to `snap_daemon` user. Further
+        # running `bash -c` will mean that we won't have access to the local variable 
+        # PBM_MONGODB_URI. So we should specify the entire path of the file.
         "${SNAP}"/usr/bin/setpriv \
             --clear-groups \
             --reuid snap_daemon \
             --regid snap_daemon -- \
-            bash -c 'echo "# this file is to be left empty. Changes in this file will be ignored." > ${PBM_CONFIG_FILE}'
+            bash -c 'echo "# this file is to be left empty. Changes in this file will be ignored." > "${SNAP_DATA}/etc/pbm/pbm_config.yaml"'
     else 
         echo "uri incorrect failed to correctly set config" 
         # SNAP_DATA is not writable by root - so we must switch to `snap_daemon` user. 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -8,6 +8,7 @@ set -eux
 # to SNAP_USER_DATA
 mkdir -p "${SNAP_USER_DATA}/etc/pbm/"
 PBM_CONFIG_FILE="${SNAP_USER_DATA}/etc/pbm/pbm_config.yaml"
+export PBM_MONGODB_URI="$(snapctl get pbm-uri)"
 
 # PBM requires that a config file was set up in order to facilitate further congurations. 
 #   i.e. with pbm config --set key=value
@@ -15,8 +16,7 @@ PBM_CONFIG_FILE="${SNAP_USER_DATA}/etc/pbm/pbm_config.yaml"
 # and fail. Therefore it is necessary to only set the config file once.
 # Further, setting the config requires that the uri has already been set and that the URI is valid
 # so we must do it after the user sets the uri.
-if [  -n "$(snapctl get pbm-uri)"  ] && [ ! -f "${PBM_CONFIG_FILE}" ]; then
-    export PBM_MONGODB_URI="$(snapctl get pbm-uri)"
+if [  -n "${PBM_MONGODB_URI}"  ] && [ ! -f "${PBM_CONFIG_FILE}" ]; then
     touch "${PBM_CONFIG_FILE}"
 
     # if the URI is incorrect then the config file will be ignored and it is necessary to try again

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -2,18 +2,30 @@
 
 set -eux
 
-CONFIG_FILE="${SNAP_DATA}/etc/pbm/pbm_config.yaml"
 
-# set the config file for pbm
-PBM_MONGODB_URI=$(snapctl get pbm-uri)
-if [ -n "${PBM_MONGODB_URI}" ]; then
-    export PBM_MONGODB_URI
+# We use the pbm config file as an indicator that the config has been correctly set by pbm. 
+# The confinement of this snap prevents it from writing to `SNAP_DATA` so instead we write
+# to SNAP_USER_DATA
+mkdir -p "${SNAP_USER_DATA}/etc/pbm/"
+PBM_CONFIG_FILE="${SNAP_USER_DATA}/etc/pbm/pbm_config.yaml"
 
-    # pbm requires that a config file was set up in order to facilitate further congurations. Note 
-    # snaps require special permissions to read files outside of the typical snap directories so
-    # it is important that we set this to a file the snap is able to access.
-    # Further, this command requires that the uri has already been set so we must do it after the
-    # user sets the uri
-    "$SNAP/usr/bin/pbm" config --file "${CONFIG_FILE}"
+# PBM requires that a config file was set up in order to facilitate further congurations. 
+#   i.e. with pbm config --set key=value
+# However reseting the config file while PBM is running causes PBM to lose existing configurations
+# and fail. Therefore it is necessary to only set the config file once.
+# Further, setting the config requires that the uri has already been set and that the URI is valid
+# so we must do it after the user sets the uri.
+if [  -n "$(snapctl get pbm-uri)"  ] && [ ! -f "${PBM_CONFIG_FILE}" ]; then
+    export PBM_MONGODB_URI="$(snapctl get pbm-uri)"
+    touch "${PBM_CONFIG_FILE}"
+
+    # if the URI is incorrect then the config file will be ignored and it is necessary to try again
+    # with a correct uri.
+    if "$SNAP/usr/bin/pbm" config --file "${PBM_CONFIG_FILE}"; then
+        echo "# this file is to be left empty. Changes in this file will be ignored." > ${PBM_CONFIG_FILE}
+    else 
+        echo "uri incorrect failed to correctly set config" 
+        rm "${PBM_CONFIG_FILE}"
+    fi
 fi
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -2,12 +2,8 @@
 
 set -eux
 
-
 # We use the pbm config file as an indicator that the config has been correctly set by pbm. 
-# The confinement of this snap prevents it from writing to `SNAP_DATA` so instead we write
-# to SNAP_USER_DATA
-mkdir -p "${SNAP_USER_DATA}/etc/pbm/"
-PBM_CONFIG_FILE="${SNAP_USER_DATA}/etc/pbm/pbm_config.yaml"
+PBM_CONFIG_FILE="${SNAP_DATA}/etc/pbm/pbm_config.yaml"
 export PBM_MONGODB_URI="$(snapctl get pbm-uri)"
 
 # PBM requires that a config file was set up in order to facilitate further congurations. 
@@ -17,15 +13,30 @@ export PBM_MONGODB_URI="$(snapctl get pbm-uri)"
 # Further, setting the config requires that the uri has already been set and that the URI is valid
 # so we must do it after the user sets the uri.
 if [  -n "${PBM_MONGODB_URI}"  ] && [ ! -f "${PBM_CONFIG_FILE}" ]; then
-    touch "${PBM_CONFIG_FILE}"
+    # SNAP_DATA is not writable by root - so we must switch to `snap_daemon` user. 
+    "${SNAP}"/usr/bin/setpriv \
+        --clear-groups \
+        --reuid snap_daemon \
+        --regid snap_daemon -- \
+        touch "${PBM_CONFIG_FILE}"
 
     # if the URI is incorrect then the config file will be ignored and it is necessary to try again
     # with a correct uri.
     if "$SNAP/usr/bin/pbm" config --file "${PBM_CONFIG_FILE}"; then
-        echo "# this file is to be left empty. Changes in this file will be ignored." > ${PBM_CONFIG_FILE}
+        # SNAP_DATA is not writable by root - so we must switch to `snap_daemon` user. 
+        "${SNAP}"/usr/bin/setpriv \
+            --clear-groups \
+            --reuid snap_daemon \
+            --regid snap_daemon -- \
+            bash -c 'echo "# this file is to be left empty. Changes in this file will be ignored." > ${PBM_CONFIG_FILE}'
     else 
         echo "uri incorrect failed to correctly set config" 
-        rm "${PBM_CONFIG_FILE}"
+        # SNAP_DATA is not writable by root - so we must switch to `snap_daemon` user. 
+        exec "${SNAP}"/usr/bin/setpriv \
+            --clear-groups \
+            --reuid snap_daemon \
+            --regid snap_daemon -- \
+            rm "${PBM_CONFIG_FILE}"
     fi
 fi
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -8,10 +8,6 @@ mkdir -p "${SNAP_DATA}/etc/mongod/"
 mkdir -p "${SNAP_COMMON}/var/lib/mongodb/"
 mkdir -p "${SNAP_COMMON}/var/log/mongodb/"
 
-# Create the config file that is used by pbm along with the directories
-PBM_CONFIG_FILE="${SNAP_DATA}/etc/pbm/pbm_config.yaml"
-touch "${PBM_CONFIG_FILE}"
-
 # Copy over the mongod.conf and create needed directories/files
 MONGO_CONFIG_FILE="${SNAP_DATA}/etc/mongod/mongod.conf"
 echo "configuration file does not exist."


### PR DESCRIPTION
## Problem
Resetting the config file every time the user runs `sudo snap set` results in `pbm` loosing all of its configs and breaking

## Context
1. We don't have perms to touch `SNAP_DATA` within the `configure` hook 
2. We cannot set the config file from the `install` hook since it requires a **valid** URI

## Solution
Set the config file only once
