### PR TITLE
[DPE-2559] run mongos as daemon

### DIFF
--- a/snap/local/start-mongos.sh
+++ b/snap/local/start-mongos.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# For security measures, daemons should not be run as sudo. Execute mongos as the non-sudo user: snap-daemon.
+exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
+  --regid snap_daemon -- $SNAP/usr/bin/mongos ${MONGOS_ARGS} "$@"
+  
+   

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,7 +89,14 @@ apps:
       - network
       - network-bind
   mongos:
-    command: drop_priv.sh mongos
+    daemon: simple
+    install-mode: disable
+    command: start-mongos.sh
+    restart-condition: always
+    restart-delay: 20s
+    plugs:
+      - network
+      - network-bind
     slots:
       - logs
   mongostat:


### PR DESCRIPTION
## problem
`mongos` is currently being run as a command instead of as a daemon

## solution
run `mongos` as a daemon. Do this with proper security measures and adopt method of using env vars to pass options