### PR TITLE
hide config-server uri

### DIFF
--- a/snap/local/start-mongos.sh
+++ b/snap/local/start-mongos.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # For security measures, daemons should not be run as sudo. Execute mongos as the non-sudo user: snap-daemon.
+export CONFIG_SERVER_URI="$(snapctl get config-uri)"
+
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/bin/mongos ${MONGOS_ARGS} "$@"
+  --regid snap_daemon -- $SNAP/usr/bin/mongos ${MONGOS_ARGS} --configdb $CONFIG_SERVER_URI "$@"
   
    


### PR DESCRIPTION
## Problem
config server URI can be seen in `/etc/environment` this contains the username and password to the server. bad security practice

## Context
`mongos` daemon starts and reads arguments in `/etc/environment`. One of the necessary arguments to start `mongos` is the URI for the config server. The URI contains the username and password to the server. This means the credentials are stored in plain text

## Solution 
pass the URI with `sudo snap set`