### PR TITLE
enable-startup

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,6 +64,7 @@ apps:
   mongod:
     command: start-mongod.sh
     daemon: simple
+    install-mode: disable
     restart-condition: always
     restart-delay: 20s
     plugs:
@@ -89,6 +90,7 @@ apps:
       - network-bind
   mongos:
     daemon: simple
+    install-mode: disable
     command: start-mongos.sh
     restart-condition: always
     restart-delay: 20s
@@ -103,6 +105,7 @@ apps:
     command: drop_priv.sh mongotop
   mongodb-exporter:
     daemon: simple
+    install-mode: disable
     # wrapper is used to run mongodb-exporter as snap_daemon user
     # and pass the URI via `snapctl`.
     command: start-mongodb-exporter.sh
@@ -121,6 +124,7 @@ apps:
       - network-bind
   pbm-agent:
     daemon: simple
+    install-mode: disable
     # pbm-agent requires a variable for the mongodb uri,
     # enviornment variables are not available to snap daemons,
     # so they must be passed/loaded via `snapctl`. Handling of

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,7 +64,6 @@ apps:
   mongod:
     command: start-mongod.sh
     daemon: simple
-    install-mode: disable
     restart-condition: always
     restart-delay: 20s
     plugs:
@@ -90,7 +89,6 @@ apps:
       - network-bind
   mongos:
     daemon: simple
-    install-mode: disable
     command: start-mongos.sh
     restart-condition: always
     restart-delay: 20s


### PR DESCRIPTION
All daemons on snap (except mongod and mongos) enable start-up (i.e. they enable the service to start when the system starts up). Enabling start up can help with high-availability in the case that the system stops and starts again. 