### PR TITLE
disable all startup services

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -105,6 +105,7 @@ apps:
     command: drop_priv.sh mongotop
   mongodb-exporter:
     daemon: simple
+    install-mode: disable
     # wrapper is used to run mongodb-exporter as snap_daemon user
     # and pass the URI via `snapctl`.
     command: start-mongodb-exporter.sh
@@ -123,6 +124,7 @@ apps:
       - network-bind
   pbm-agent:
     daemon: simple
+    install-mode: disable
     # pbm-agent requires a variable for the mongodb uri,
     # enviornment variables are not available to snap daemons,
     # so they must be passed/loaded via `snapctl`. Handling of


### PR DESCRIPTION
It doesn't make sense for  any of the daemons in charmed-mongodb snap to start up automatically in the snap. They require specific configurations and an up and a running mongos instance. We can keep them enabled, but they will show an error state:
```
ubuntu@ip-172-31-37-213:~$ sudo snap logs charmed-mongodb.pbm-agent
2023-09-16T14:25:39Z systemd[1]: Started Service for snap application charmed-mongodb.pbm-agent.
2023-09-16T14:25:39Z charmed-mongodb.pbm-agent[4119638]: 2023/09/16 14:25:39 Error: Parse command line parameters: required flag --mongodb-uri not provided
2023-09-16T14:25:39Z systemd[1]: snap.charmed-mongodb.pbm-agent.service: Deactivated successfully.
```