### PR TITLE
[DPE-2666] Move to pbm built from source

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,13 +37,9 @@ package-repositories:
   - type: apt
     components: [main]
     suites: [jammy]
-    key-id: 4D1BB29D63D98E422B2113B19334A25F8507EFA5
-    url: http://repo.percona.com/percona/apt
-  - type: apt
-    components: [main]
-    suites: [jammy]
-    key-id: 4D1BB29D63D98E422B2113B19334A25F8507EFA5
-    url: http://repo.percona.com/pbm/apt
+    key-id: 6676E3F1A76ADBE4488944BF7D1A96D4BF78C79E
+    url: |
+        https://ppa.launchpadcontent.net/data-platform/percona-backup-mongodb/ubuntu
 
 slots:
   logs:


### PR DESCRIPTION
This PR implements [DPE-2666](https://warthogs.atlassian.net/browse/DPE-2666):

Moves away from PBM present in repo.percona.com` to DPE's built from source for PBM: https://launchpad.net/~data-platform/+archive/ubuntu/percona-backup-mongodb

[DPE-2666]: https://warthogs.atlassian.net/browse/DPE-2666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ