### PR TITLE
Allow to read logs by root

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -22,6 +22,7 @@ sed -i "s:/var/lib/mongodb:$SNAP_COMMON/var/lib/mongodb:g" $MONGO_CONFIG_FILE
 sed -i "s:/var/run:/tmp:g" $MONGO_CONFIG_FILE
 
 # Change ownership of snap directories to allow snap_daemon to read/write
-chown -R 584788:root ${SNAP_DATA}/*
-chown -R 584788:root ${SNAP_COMMON}/*
-
+chown -R 584788:root "${SNAP_DATA}"/*
+chown -R 584788:root "${SNAP_COMMON}"/*
+chgrp root "${SNAP_COMMON}/var/log/"*
+chmod g+s "${SNAP_COMMON}/var/log/"*

--- a/snap/local/start-mongod.sh
+++ b/snap/local/start-mongod.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
 # For security measures, daemons should not be run as sudo. Execute mongod as the non-sudo user: snap-daemon.
-exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/bin/mongod --config ${SNAP_DATA}/etc/mongod/mongod.conf ${MONGOD_ARGS} "$@"
+exec \
+  "${SNAP}/usr/bin/setpriv" \
+  --clear-groups \
+  --reuid snap_daemon \
+  --regid snap_daemon \
+  -- \
+  "${SNAP}/usr/bin/mongod" \
+      --config "${SNAP_DATA}/etc/mongod/mongod.conf" \
+      --setParameter processUmask=037 \
+      "${MONGOD_ARGS}" \
+      "$@"


### PR DESCRIPTION
This PR: 
- allows the `root` user to read logs from `${SNAP_COMMON}/var/log/`
    - this is done through the mongod parameter `processUmask=037` set on start
- ensures that every new file created in `${SNAP_COMMON}/var/log/` are created with the `root` group.
    - this is done through `chgrp` + `chmod g+s`

