### PR TITLE
Added publish badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Charmed MongoDB Snap
+[![.github/workflows/publish.yaml](https://github.com/canonical/charmed-mongodb-snap/actions/workflows/publish.yaml/badge.svg)](https://github.com/canonical/charmed-mongodb-snap/actions/workflows/publish.yaml)
+
 This repository contains the packaging metadata for creating a snap of Charmed MongoDB built from the official percona debian repositories. For more information on snaps, visit [snapcraft.io](https://snapcraft.io/). 
 
 ## Installing the Snap


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added a badge for the `publish.yaml` workflow

@ reviewers: Should we merge this into 5/edge or 6/edge?