### PR TITLE
Bumped version of mongodb exporter

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -178,7 +178,7 @@ parts:
   percona-mongodb-exporter:
     plugin: dump
     source: "https://github.com/percona/mongodb_exporter/releases/download\
-      /v0.39.0/mongodb_exporter-0.39.0.linux-64-bit.deb"
+      /v0.40.0/mongodb_exporter-0.40.0.linux-64-bit.deb"
   wrapper:
     plugin: dump
     source: snap/local
@@ -198,5 +198,5 @@ parts:
       PERCONA_GH=https://raw.githubusercontent.com/percona
       craftctl default
       mkdir -p $CRAFT_PART_INSTALL/licenses
-      wget ${PERCONA_GH}/mongodb_exporter/v0.39.0/LICENSE \
+      wget ${PERCONA_GH}/mongodb_exporter/v0.40.0/LICENSE \
         -O $CRAFT_PART_INSTALL/licenses/LICENSE-mongodb-exporter


### PR DESCRIPTION
This PR bumps the version of the mongodb exporter from `0.39.0` to `0.40.0`
(we also wanna trigger a new build of the snap to update `pbm`)