### PR TITLE
feat: Do not change permissions on existing data directory

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -15,11 +15,13 @@ mkdir -p $LOGS
 mkdir -p $PBM_CONF
 mkdir -p $CONF
 
+# If we just created the directory, we set up permissions
 if [ stat -c '%u' "$DATA" == 0 -o ! -d "$DATA" ]; then
     chmod -R 770 "${SNAP_COMMON}"
     chmod 750 "${DATA}"
 fi
 
+# If we just created the directory, we set up permissions
 if [ stat -c '%u' "$LOGS" == 0 -o ! -d "$LOGS" ]; then
     chmod -R 770 "${SNAP_COMMON}"
     chmod g+s "$LOGS"/*

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -16,13 +16,13 @@ mkdir -p $PBM_CONF
 mkdir -p $CONF
 
 # If we just created the directory, we set up permissions
-if [ stat -c '%u' "$DATA" == 0 -o ! -d "$DATA" ]; then
+if [ stat -c '%u' "$DATA" == 0 ]; then
     chmod -R 770 "${SNAP_COMMON}"
     chmod 750 "${DATA}"
 fi
 
 # If we just created the directory, we set up permissions
-if [ stat -c '%u' "$LOGS" == 0 -o ! -d "$LOGS" ]; then
+if [ stat -c '%u' "$LOGS" == 0 ]; then
     chmod -R 770 "${SNAP_COMMON}"
     chmod g+s "$LOGS"/*
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,15 +1,32 @@
 #!/bin/bash
+# Installation hook for charmed-mongodb snap
 
 set -eux
 
+export CONF="${SNAP_DATA}/etc/mongod"
+export PBM_CONF="${SNAP_DATA}/etc/pbm/"
+export DATA="${SNAP_COMMON}/var/lib/mongodb"
+export LOG="${SNAP_COMMON}/var/log/mongodb"
+
+# If the $DATA dir is not there yet, create it
+if [ stat -c '%u' "$DATA" == 0 -o ! -d "$DATA" ]; then
+    mkdir -p $DATA
+    mkdir -p $LOG
+    chmod g+s "${LOG}"/*
+    chown -R 584788:root "${SNAP_COMMON}"/*
+    chgrp root "${LOG}"*
+else
+    mkdir -p $LOG
+    chmod g+s "$LOG"*
+    chgrp root "${LOG}"*
+fi
+
 # Create the necessary parent directories 
-mkdir -p "${SNAP_DATA}/etc/pbm/"
-mkdir -p "${SNAP_DATA}/etc/mongod/"
-mkdir -p "${SNAP_COMMON}/var/lib/mongodb/"
-mkdir -p "${SNAP_COMMON}/var/log/mongodb/"
+mkdir -p "${PBM_CONF}"
+mkdir -p "${CONF}"
 
 # Copy over the mongod.conf and create needed directories/files
-MONGO_CONFIG_FILE="${SNAP_DATA}/etc/mongod/mongod.conf"
+MONGO_CONFIG_FILE="${CONF}/mongod.conf"
 echo "configuration file does not exist."
 echo "copying default config to ${MONGO_CONFIG_FILE}"
 cp -r ${SNAP}/etc/mongod.conf ${MONGO_CONFIG_FILE}
@@ -17,12 +34,9 @@ cp -r ${SNAP}/etc/mongod.conf ${MONGO_CONFIG_FILE}
 
 # mongod.conf default values are not consistent with the snap directory system.
 sed -i "s/fork: true/fork: false/g" $MONGO_CONFIG_FILE
-sed -i "s:/var/log/mongodb:$SNAP_COMMON/var/log/mongodb:g" $MONGO_CONFIG_FILE
-sed -i "s:/var/lib/mongodb:$SNAP_COMMON/var/lib/mongodb:g" $MONGO_CONFIG_FILE
+sed -i "s:/var/log/mongodb:$LOG:g" $MONGO_CONFIG_FILE
+sed -i "s:/var/lib/mongodb:$DATA:g" $MONGO_CONFIG_FILE
 sed -i "s:/var/run:/tmp:g" $MONGO_CONFIG_FILE
 
 # Change ownership of snap directories to allow snap_daemon to read/write
-chmod g+s "${SNAP_COMMON}/var/log/"*
 chown -R 584788:root "${SNAP_DATA}"/*
-chown -R 584788:root "${SNAP_COMMON}"/*
-chgrp root "${SNAP_COMMON}/var/log/"*

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -21,7 +21,7 @@ if [ stat -c '%u' "$DATA" == 0 -o ! -d "$DATA" ]; then
 fi
 
 if [ stat -c '%u' "$LOGS" == 0 -o ! -d "$LOGS" ]; then
-    chmod -R 770 "${LOGS}"
+    chmod -R 770 "${SNAP_COMMON}"
     chmod g+s "$LOGS"/*
 fi
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,32 +1,33 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Installation hook for charmed-mongodb snap
 
 set -eux
 
-export CONF="${SNAP_DATA}/etc/mongod"
-export PBM_CONF="${SNAP_DATA}/etc/pbm/"
-export DATA="${SNAP_COMMON}/var/lib/mongodb"
-export LOG="${SNAP_COMMON}/var/log/mongodb"
-
-# If the $DATA dir is not there yet, create it
-if [ stat -c '%u' "$DATA" == 0 -o ! -d "$DATA" ]; then
-    mkdir -p $DATA
-    mkdir -p $LOG
-    chmod g+s "${LOG}"/*
-    chown -R 584788:root "${SNAP_COMMON}"/*
-    chgrp root "${LOG}"*
-else
-    mkdir -p $LOG
-    chmod g+s "$LOG"*
-    chgrp root "${LOG}"*
-fi
+export CONF="${SNAP_DATA}"/etc/mongod
+export PBM_CONF="${SNAP_DATA}"/etc/pbm
+export DATA="${SNAP_COMMON}"/var/lib/mongodb
+export LOGS="${SNAP_COMMON}"/var/log/mongodb
+export MONGO_CONFIG_FILE="${CONF}"/mongod.conf
 
 # Create the necessary parent directories 
-mkdir -p "${PBM_CONF}"
-mkdir -p "${CONF}"
+mkdir -p $DATA
+mkdir -p $LOGS
+mkdir -p $PBM_CONF
+mkdir -p $CONF
+
+if [ stat -c '%u' "$DATA" == 0 -o ! -d "$DATA" ]; then
+    chmod -R 770 "${SNAP_COMMON}"
+    chmod 750 "${DATA}"
+fi
+
+if [ stat -c '%u' "$LOGS" == 0 -o ! -d "$LOGS" ]; then
+    chmod -R 770 "${LOGS}"
+    chmod g+s "$LOGS"/*
+fi
+
+chown -R 584788:root "${SNAP_COMMON}"/*
 
 # Copy over the mongod.conf and create needed directories/files
-MONGO_CONFIG_FILE="${CONF}/mongod.conf"
 echo "configuration file does not exist."
 echo "copying default config to ${MONGO_CONFIG_FILE}"
 cp -r ${SNAP}/etc/mongod.conf ${MONGO_CONFIG_FILE}
@@ -34,7 +35,7 @@ cp -r ${SNAP}/etc/mongod.conf ${MONGO_CONFIG_FILE}
 
 # mongod.conf default values are not consistent with the snap directory system.
 sed -i "s/fork: true/fork: false/g" $MONGO_CONFIG_FILE
-sed -i "s:/var/log/mongodb:$LOG:g" $MONGO_CONFIG_FILE
+sed -i "s:/var/log/mongodb:$LOGS:g" $MONGO_CONFIG_FILE
 sed -i "s:/var/lib/mongodb:$DATA:g" $MONGO_CONFIG_FILE
 sed -i "s:/var/run:/tmp:g" $MONGO_CONFIG_FILE
 


### PR DESCRIPTION
 * When we attach an existing volume with charmed mongodb `$DATA` directory already existing, the former version would break when trying to change the permissions of `$DATA`.
 * This version, similar as https://github.com/canonical/charmed-kafka-snap/pull/40 fixes this issue