### PR TITLE
fix: chdir to $SNAP before running command

### DIFF
--- a/snap/local/drop_priv.sh
+++ b/snap/local/drop_priv.sh
@@ -4,13 +4,14 @@
 export PBM_MONGODB_URI="$(snapctl get pbm-uri)"
 
 if [[ $(id -u) == "0" ]]; then
-
-exec "${SNAP}"/usr/bin/setpriv \
+    exec bash -c "cd ${SNAP} && \
+        ${SNAP}/usr/bin/setpriv \
         --clear-groups \
         --reuid snap_daemon \
-        --regid snap_daemon -- \
-        "$SNAP/usr/bin/$@"
+        --regid snap_daemon \
+        -- \
+        ${SNAP}/usr/bin/$*"
 else
-
-exec "$SNAP/usr/bin/$@"
+    exec bash -c "cd ${SNAP} && \
+        ${SNAP}/usr/bin/$*"
 fi


### PR DESCRIPTION
## Issue

Could not start shell as root in mongos because of directory permission issues.

## Solution

`cd` to ${SNAP} before running the command.
Also, shellcheck and move from insecure `$@` to `$*`.