### PR TITLE
fix: cd before exec for argument

### DIFF
--- a/snap/local/drop_priv.sh
+++ b/snap/local/drop_priv.sh
@@ -3,15 +3,15 @@
 
 export PBM_MONGODB_URI="$(snapctl get pbm-uri)"
 
+
+
 if [[ $(id -u) == "0" ]]; then
-    exec bash -c "cd ${SNAP} && \
-        ${SNAP}/usr/bin/setpriv \
+    cd ${SNAP} && exec "${SNAP}"/usr/bin/setpriv \
         --clear-groups \
         --reuid snap_daemon \
         --regid snap_daemon \
         -- \
-        ${SNAP}/usr/bin/$*"
+        "${SNAP}/usr/bin/$@"
 else
-    exec bash -c "cd ${SNAP} && \
-        ${SNAP}/usr/bin/$*"
+    cd ${SNAP} && exec "${SNAP}/usr/bin/$@"
 fi

--- a/snap/local/drop_priv.sh
+++ b/snap/local/drop_priv.sh
@@ -3,15 +3,17 @@
 
 export PBM_MONGODB_URI="$(snapctl get pbm-uri)"
 
-
+pushd "${SNAP}" > /dev/null
 
 if [[ $(id -u) == "0" ]]; then
-    cd ${SNAP} && exec "${SNAP}"/usr/bin/setpriv \
+    exec "${SNAP}"/usr/bin/setpriv \
         --clear-groups \
         --reuid snap_daemon \
         --regid snap_daemon \
         -- \
         "${SNAP}/usr/bin/$@"
 else
-    cd ${SNAP} && exec "${SNAP}/usr/bin/$@"
+    exec "${SNAP}/usr/bin/$@"
 fi
+
+popd > /dev/null


### PR DESCRIPTION
Removed the `bash -c` and externalized the `cd` to outside the context of the `exec`