### PR TITLE
feat: Use snap config for starting services

### DIFF
--- a/snap/local/start-mongod.sh
+++ b/snap/local/start-mongod.sh
@@ -8,6 +8,11 @@ ulimit -Sl unlimited
 ulimit -SHn 64000
 ulimit -SHu 64000
 
+SNAP_ARGS="$(snapctl get mongod-args)"
+
+if [[ -n "${SNAP_ARGS}" ]]; then
+    MONGOD_ARGS=$SNAP_ARGS
+fi
 # For security measures, daemons should not be run as sudo. Execute mongod as the non-sudo user: snap-daemon.
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
   --regid snap_daemon -- $SNAP/usr/bin/mongod --config ${SNAP_DATA}/etc/mongod/mongod.conf ${MONGOD_ARGS} "$@"

--- a/snap/local/start-mongod.sh
+++ b/snap/local/start-mongod.sh
@@ -11,7 +11,7 @@ ulimit -SHu 64000
 SNAP_ARGS="$(snapctl get mongod-args)"
 
 if [[ -n "${SNAP_ARGS}" ]]; then
-    MONGOD_ARGS=$SNAP_ARGS
+    MONGOD_ARGS="${SNAP_ARGS}"
 fi
 # For security measures, daemons should not be run as sudo. Execute mongod as the non-sudo user: snap-daemon.
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \

--- a/snap/local/start-mongos.sh
+++ b/snap/local/start-mongos.sh
@@ -8,6 +8,12 @@ ulimit -Sl unlimited
 ulimit -SHn 64000
 ulimit -SHu 64000
 
+SNAP_ARGS="$(snapctl get mongos-args)"
+
+if [[ -n "${SNAP_ARGS}" ]]; then
+    MONGOS_ARGS=$SNAP_ARGS
+fi
+
 # For security measures, daemons should not be run as sudo. Execute mongos as the non-sudo user: snap-daemon.
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
   --regid snap_daemon -- $SNAP/usr/bin/mongos ${MONGOS_ARGS} "$@"

--- a/snap/local/start-mongos.sh
+++ b/snap/local/start-mongos.sh
@@ -11,7 +11,7 @@ ulimit -SHu 64000
 SNAP_ARGS="$(snapctl get mongos-args)"
 
 if [[ -n "${SNAP_ARGS}" ]]; then
-    MONGOS_ARGS=$SNAP_ARGS
+    MONGOS_ARGS="${SNAP_ARGS}"
 fi
 
 # For security measures, daemons should not be run as sudo. Execute mongos as the non-sudo user: snap-daemon.


### PR DESCRIPTION
## What is this about?

With the work of codebase unification in [mongo-single-kernel-library](https://github.com/canonical/mongo-single-kernel-library), the unification of service handling workflow makes it easier to set the configuration using snap configuration options.
This is a also a bit safer as you need to be allowed to read the snap config while the former usecase was writing in the default environment file.

This PR maintains backward compatibility by falling back on environment variable if no configuration is found.