### PR TITLE
feat(DPE-6717): Update snaps to use config file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: snapcore/action-build@v1
         id: build
       - name: Upload locally built Snap artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snap-artifact
           path: ${{ steps.build.outputs.snap }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: snap-artifact
       - id: get-snap-name

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install tox
         run: python3 -m pip install tox
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: snap-artifact
       - name: Smoke Tests

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -43,17 +43,17 @@ cp -r ${SNAP}/etc/mongod.conf ${MONGOS_CONFIG_FILE}
 
 
 # mongod.conf default values are not consistent with the snap directory system.
-yq -i '.processManagement.fork = false' $MONGO_CONFIG_FILE
-yq -i '.systemLog.path = $LOGS' $MONGO_CONFIG_FILE
-yq -i '.storage.dbPath = $DATA' $MONGO_CONFIG_FILE
-yq -i '.processManagement.pidFilePath = /tmp/mongod.pid' $MONGO_CONFIG_FILE
+yq -i ".processManagement.fork = false" $MONGO_CONFIG_FILE
+yq -i ".systemLog.path = \"${LOGS}/mongodb.log\"" $MONGO_CONFIG_FILE
+yq -i ".storage.dbPath = \"${DATA}\"" $MONGO_CONFIG_FILE
+yq -i ".processManagement.pidFilePath = \"/tmp/mongod.pid\"" $MONGO_CONFIG_FILE
 
 # mongos.conf default values are not consistent with the snap directory system.
-yq -i '.processManagement.fork = false' $MONGOS_CONFIG_FILE
-yq -i '.systemLog.path = $LOGS' $MONGOS_CONFIG_FILE
-yq -i '.processManagement.pidFilePath = /tmp/mongos.pid' $MONGOS_CONFIG_FILE
-yq -i '.net.port = 27018' $MONGOS_CONFIG_FILE
-yq -i 'del(.storage)' $MONGOS_CONFIG_FILE
+yq -i ".processManagement.fork = false" $MONGOS_CONFIG_FILE
+yq -i ".systemLog.path = \"${LOGS}/mongodb.log\"" $MONGOS_CONFIG_FILE
+yq -i ".processManagement.pidFilePath = \"/tmp/mongos.pid\"" $MONGOS_CONFIG_FILE
+yq -i ".net.port = 27018" $MONGOS_CONFIG_FILE
+yq -i "del(.storage)" $MONGOS_CONFIG_FILE
 
 # Change ownership of snap directories to allow snap_daemon to read/write
 chown -R 584788:root "${SNAP_DATA}"/*

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -43,18 +43,16 @@ cp -r ${SNAP}/etc/mongod.conf ${MONGOS_CONFIG_FILE}
 
 
 # mongod.conf default values are not consistent with the snap directory system.
-sed -i "s/fork: true/fork: false/g" $MONGO_CONFIG_FILE
-sed -i "s:/var/log/mongodb:$LOGS:g" $MONGO_CONFIG_FILE
-sed -i "s:/var/lib/mongodb:$DATA:g" $MONGO_CONFIG_FILE
-sed -i "s:/var/run:/tmp:g" $MONGO_CONFIG_FILE
+yq -i '.processManagement.fork = false' $MONGO_CONFIG_FILE
+yq -i '.systemLog.path = $LOGS' $MONGO_CONFIG_FILE
+yq -i '.storage.dbPath = $DATA' $MONGO_CONFIG_FILE
+yq -i '.processManagement.pidFilePath = /tmp/mongod.pid' $MONGO_CONFIG_FILE
 
 # mongos.conf default values are not consistent with the snap directory system.
-sed -i "s/fork: true/fork: false/g" $MONGOS_CONFIG_FILE
-sed -i "s:/var/log/mongodb:$LOGS:g" $MONGOS_CONFIG_FILE
-sed -i "s:/var/lib/mongodb:$DATA:g" $MONGOS_CONFIG_FILE
-sed -i "s:/var/run:/tmp:g" $MONGOS_CONFIG_FILE
-sed -i "s/mongod.pid/mongos.pid/g" $MONGOS_CONFIG_FILE
-sed -i "s/port: 27017/port: 27018/g" $MONGOS_CONFIG_FILE
+yq -i '.processManagement.fork = false' $MONGOS_CONFIG_FILE
+yq -i '.systemLog.path = $LOGS' $MONGOS_CONFIG_FILE
+yq -i '.processManagement.pidFilePath = /tmp/mongos.pid' $MONGOS_CONFIG_FILE
+yq -i '.net.port = 27018' $MONGOS_CONFIG_FILE
 yq -i 'del(.storage)' $MONGOS_CONFIG_FILE
 
 # Change ownership of snap directories to allow snap_daemon to read/write

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -43,17 +43,15 @@ cp -r ${SNAP}/etc/mongod.conf ${MONGOS_CONFIG_FILE}
 
 
 # mongod.conf default values are not consistent with the snap directory system.
-yq -i ".processManagement.fork = false" $MONGO_CONFIG_FILE
-yq -i ".systemLog.path = \"${LOGS}/mongodb.log\"" $MONGO_CONFIG_FILE
-yq -i ".storage.dbPath = \"${DATA}\"" $MONGO_CONFIG_FILE
-yq -i ".processManagement.pidFilePath = \"/tmp/mongod.pid\"" $MONGO_CONFIG_FILE
+yq -i ".processManagement.fork = false" ${MONGO_CONFIG_FILE}
+yq -i ".systemLog.path = \"${LOGS}/mongod.log\"" ${MONGO_CONFIG_FILE}
+yq -i ".storage.dbPath = \"${DATA}\"" ${MONGO_CONFIG_FILE}
 
 # mongos.conf default values are not consistent with the snap directory system.
-yq -i ".processManagement.fork = false" $MONGOS_CONFIG_FILE
-yq -i ".systemLog.path = \"${LOGS}/mongodb.log\"" $MONGOS_CONFIG_FILE
-yq -i ".processManagement.pidFilePath = \"/tmp/mongos.pid\"" $MONGOS_CONFIG_FILE
-yq -i ".net.port = 27018" $MONGOS_CONFIG_FILE
-yq -i "del(.storage)" $MONGOS_CONFIG_FILE
+yq -i ".processManagement.fork = false" ${MONGOS_CONFIG_FILE}
+yq -i ".systemLog.path = \"${LOGS}/mongod.log\"" ${MONGOS_CONFIG_FILE}
+yq -i ".net.port = 27018" ${MONGOS_CONFIG_FILE}
+yq -i "del(.storage)" ${MONGOS_CONFIG_FILE}
 
 # Change ownership of snap directories to allow snap_daemon to read/write
 chown -R 584788:root "${SNAP_DATA}"/*

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -8,6 +8,7 @@ export PBM_CONF="${SNAP_DATA}"/etc/pbm
 export DATA="${SNAP_COMMON}"/var/lib/mongodb
 export LOGS="${SNAP_COMMON}"/var/log/mongodb
 export MONGO_CONFIG_FILE="${CONF}"/mongod.conf
+export MONGOS_CONFIG_FILE="${CONF}"/mongos.conf
 
 # Create the necessary parent directories 
 mkdir -p $DATA
@@ -30,9 +31,15 @@ fi
 chown -R 584788:root "${SNAP_COMMON}"/*
 
 # Copy over the mongod.conf and create needed directories/files
-echo "configuration file does not exist."
+echo "mongod configuration file does not exist."
 echo "copying default config to ${MONGO_CONFIG_FILE}"
 cp -r ${SNAP}/etc/mongod.conf ${MONGO_CONFIG_FILE}
+
+# Copy over the mongos.conf and create needed directories/files
+echo "mongos configuration file does not exist."
+echo "copying default config to ${MONGOS_CONFIG_FILE}"
+cp -r ${SNAP}/etc/mongod.conf ${MONGOS_CONFIG_FILE}
+
 
 
 # mongod.conf default values are not consistent with the snap directory system.
@@ -40,6 +47,15 @@ sed -i "s/fork: true/fork: false/g" $MONGO_CONFIG_FILE
 sed -i "s:/var/log/mongodb:$LOGS:g" $MONGO_CONFIG_FILE
 sed -i "s:/var/lib/mongodb:$DATA:g" $MONGO_CONFIG_FILE
 sed -i "s:/var/run:/tmp:g" $MONGO_CONFIG_FILE
+
+# mongos.conf default values are not consistent with the snap directory system.
+sed -i "s/fork: true/fork: false/g" $MONGOS_CONFIG_FILE
+sed -i "s:/var/log/mongodb:$LOGS:g" $MONGOS_CONFIG_FILE
+sed -i "s:/var/lib/mongodb:$DATA:g" $MONGOS_CONFIG_FILE
+sed -i "s:/var/run:/tmp:g" $MONGOS_CONFIG_FILE
+sed -i "s/mongod.pid/mongos.pid/g" $MONGOS_CONFIG_FILE
+sed -i "s/port: 27017/port: 27018/g" $MONGOS_CONFIG_FILE
+yq -i 'del(.storage)' $MONGOS_CONFIG_FILE
 
 # Change ownership of snap directories to allow snap_daemon to read/write
 chown -R 584788:root "${SNAP_DATA}"/*

--- a/snap/local/start-mongos.sh
+++ b/snap/local/start-mongos.sh
@@ -16,4 +16,4 @@ fi
 
 # For security measures, daemons should not be run as sudo. Execute mongos as the non-sudo user: snap-daemon.
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/usr/bin/mongos ${MONGOS_ARGS} "$@"
+  --regid snap_daemon -- $SNAP/usr/bin/mongos --config ${SNAP_DATA}/etc/mongod/mongos.conf ${MONGOS_ARGS} "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -139,6 +139,7 @@ parts:
       - percona-server-mongodb
       - percona-backup-mongodb
       - util-linux
+      - libldap-common
     stage-snaps:
       - yq
     override-prime: |
@@ -149,6 +150,8 @@ parts:
     organize:
       usr/share/doc/percona-backup-mongodb/copyright:
         licenses/LICENSE-percona-backup-mongodb
+      usr/share/doc/libldap-common/copyright:
+        licences/LICENSE-libldap-common
   mongosh-gpg:
     plugin: nil
     override-pull: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -150,8 +150,6 @@ parts:
     organize:
       usr/share/doc/percona-backup-mongodb/copyright:
         licenses/LICENSE-percona-backup-mongodb
-      usr/share/doc/libldap-common/copyright:
-        licences/LICENSE-libldap-common
   mongosh-gpg:
     plugin: nil
     override-pull: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -139,6 +139,8 @@ parts:
       - percona-server-mongodb
       - percona-backup-mongodb
       - util-linux
+    stage-snaps:
+      - yq
     override-prime: |
       craftctl default
       LICENSE_LOC=usr/share/doc/percona-server-mongodb

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ env_list = lint, smoke
 
 [testenv:lint]
 description = run linters
-allowlist_externals =
+deps =
     yamllint
     black
 commands = 
@@ -12,7 +12,7 @@ commands =
 
 [testenv:smoke]
 description = smoke test for snap
-allowlist_externals =
+deps =
     pytest
     pyyaml
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ env_list = lint, smoke
 
 [testenv:lint]
 description = run linters
-deps =
+allowlist_externals =
     yamllint
     black
 commands = 
@@ -12,7 +12,7 @@ commands =
 
 [testenv:smoke]
 description = smoke test for snap
-deps =
+allowlist_externals =
     pytest
     pyyaml
 commands =


### PR DESCRIPTION
## Problem

With LDAP integration we need to move towards config-file based configuration because we'll have to provide credentials.

## Solution

This PR adds this support on mongos as well.