### PR TITLE
feat: Add ldap configuration + post-refresh hook

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -3,6 +3,7 @@
 
 set -eux
 
+export ETC="$SNAP_DATA"/etc
 export CONF="${SNAP_DATA}"/etc/mongod
 export PBM_CONF="${SNAP_DATA}"/etc/pbm
 export DATA="${SNAP_COMMON}"/var/lib/mongodb
@@ -53,8 +54,8 @@ yq -i ".systemLog.path = \"${LOGS}/mongod.log\"" ${MONGOS_CONFIG_FILE}
 yq -i ".net.port = 27018" ${MONGOS_CONFIG_FILE}
 yq -i "del(.storage)" ${MONGOS_CONFIG_FILE}
 
-# Copy over the LDAP configuration
-cp -r "${SNAP}/etc/ldap/" "${SNAP_DATA}/etc/"
+# Copy over the LDAP configuration to keep isolation.
+cp -r "${SNAP}/etc/ldap/" "${ETC}"
 
 # Change ownership of snap directories to allow snap_daemon to read/write
 chown -R 584788:root "${SNAP_DATA}"/*

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -53,5 +53,8 @@ yq -i ".systemLog.path = \"${LOGS}/mongod.log\"" ${MONGOS_CONFIG_FILE}
 yq -i ".net.port = 27018" ${MONGOS_CONFIG_FILE}
 yq -i "del(.storage)" ${MONGOS_CONFIG_FILE}
 
+# Copy over the LDAP configuration
+cp -r ${SNAP}/etc/ldap/ "$SNAP_DATA"/etc/
+
 # Change ownership of snap directories to allow snap_daemon to read/write
 chown -R 584788:root "${SNAP_DATA}"/*

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -54,7 +54,7 @@ yq -i ".net.port = 27018" ${MONGOS_CONFIG_FILE}
 yq -i "del(.storage)" ${MONGOS_CONFIG_FILE}
 
 # Copy over the LDAP configuration
-cp -r ${SNAP}/etc/ldap/ "$SNAP_DATA"/etc/
+cp -r "${SNAP}/etc/ldap/" "${SNAP_DATA}/etc/"
 
 # Change ownership of snap directories to allow snap_daemon to read/write
 chown -R 584788:root "${SNAP_DATA}"/*

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -16,9 +16,9 @@ if [ ! -f $MONGOS_CONFIG_FILE ]; then
     echo "copying default config to ${MONGOS_CONFIG_FILE}"
 
     # Grant permissions on $CONF
-    chown root:snap_daemon $CONF
+    chown root:snap_daemon "$CONF"
 
-    cp ${SNAP}/etc/mongod.conf ${MONGOS_CONFIG_FILE}
+    cp "${SNAP}/etc/mongod.conf" "${MONGOS_CONFIG_FILE}"
 
     # mongos.conf default values are not consistent with the snap directory system.
     yq -i ".processManagement.fork = false" ${MONGOS_CONFIG_FILE}
@@ -27,7 +27,7 @@ if [ ! -f $MONGOS_CONFIG_FILE ]; then
     yq -i "del(.storage)" ${MONGOS_CONFIG_FILE}
 
     # Change ownership of snap directories to allow snap_daemon to read/write
-    chown -R 584788:root ${CONF}
+    chown -R 584788:root "${CONF}"
 fi
 
 if  [ ! -d $LDAP_CONF_DIR ]; then
@@ -36,10 +36,10 @@ if  [ ! -d $LDAP_CONF_DIR ]; then
     echo "copying default config to ${LDAP_CONF_DIR}."
 
     # Grant enough permissions to create files
-    chown root:snap_daemon $ETC
+    chown root:snap_daemon "$ETC"
 
-    cp -r ${SNAP}/etc/ldap/ "${ETC}"
+    cp -r "${SNAP}/etc/ldap/" "${ETC}"
 
     # Change ownership of snap directories to allow snap_daemon to read/write
-    chown -R 584788:root ${ETC}
+    chown -R 584788:root "${ETC}"
 fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Pre-refresh hook for charmed-mongodb snap
+
+set -eux
+
+export CONF="${SNAP_DATA}"/etc/mongod
+export MONGOS_CONFIG_FILE="${CONF}"/mongos.conf
+export LDAP_CONF_DIR="${SNAP_DATA}"/etc/ldap/
+
+if [ ! -f $MONGOS_CONFIG_FILE ]; then
+    # Copy over the mongos.conf and create needed directories/files
+    echo "mongos configuration file does not exist."
+    echo "copying default config to ${MONGOS_CONFIG_FILE}"
+    cp -r ${SNAP}/etc/mongod.conf ${MONGOS_CONFIG_FILE}
+
+    # mongos.conf default values are not consistent with the snap directory system.
+    yq -i ".processManagement.fork = false" ${MONGOS_CONFIG_FILE}
+    yq -i ".systemLog.path = \"${LOGS}/mongod.log\"" ${MONGOS_CONFIG_FILE}
+    yq -i ".net.port = 27018" ${MONGOS_CONFIG_FILE}
+    yq -i "del(.storage)" ${MONGOS_CONFIG_FILE}
+
+    # Change ownership of snap directories to allow snap_daemon to read/write
+    chown -R 584788:root ${MONGOS_CONFIG_FILE}
+fi
+
+if  [ ! -d $LDAP_CONF_DIR ]; then
+    # Copy over the LDAP configuration
+    echo "ldap configuration does not exist."
+    echo "copying default config to ${LDAP_CONF_DIR}."
+    cp -r ${SNAP}/etc/ldap/ "$SNAP_DATA"/etc/
+
+    # Change ownership of snap directories to allow snap_daemon to read/write
+    chown -R 584788:root ${LDAP_CONF_DIR}
+fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -4,14 +4,20 @@
 set -eux
 
 export CONF="${SNAP_DATA}"/etc/mongod
+export ETC="${SNAP_DATA}"/etc/
 export MONGOS_CONFIG_FILE="${CONF}"/mongos.conf
 export LOGS="${SNAP_COMMON}"/var/log/mongodb
 export LDAP_CONF_DIR="${SNAP_DATA}"/etc/ldap/
+
 
 if [ ! -f $MONGOS_CONFIG_FILE ]; then
     # Copy over the mongos.conf and create needed directories/files
     echo "mongos configuration file does not exist."
     echo "copying default config to ${MONGOS_CONFIG_FILE}"
+
+    # Grant permissions on $CONF
+    chown root:snap_daemon $CONF
+
     cp -r ${SNAP}/etc/mongod.conf ${MONGOS_CONFIG_FILE}
 
     # mongos.conf default values are not consistent with the snap directory system.
@@ -21,15 +27,19 @@ if [ ! -f $MONGOS_CONFIG_FILE ]; then
     yq -i "del(.storage)" ${MONGOS_CONFIG_FILE}
 
     # Change ownership of snap directories to allow snap_daemon to read/write
-    chown -R 584788:root ${MONGOS_CONFIG_FILE}
+    chown -R 584788:root ${CONF}
 fi
 
 if  [ ! -d $LDAP_CONF_DIR ]; then
     # Copy over the LDAP configuration
     echo "ldap configuration does not exist."
     echo "copying default config to ${LDAP_CONF_DIR}."
-    cp -r ${SNAP}/etc/ldap/ "$SNAP_DATA"/etc/
+
+    # Grant enough permissions to create files
+    chown root:snap_daemon $ETC
+
+    cp -r ${SNAP}/etc/ldap/ "${ETC}"
 
     # Change ownership of snap directories to allow snap_daemon to read/write
-    chown -R 584788:root ${LDAP_CONF_DIR}
+    chown -R 584788:root ${ETC}
 fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -5,6 +5,7 @@ set -eux
 
 export CONF="${SNAP_DATA}"/etc/mongod
 export MONGOS_CONFIG_FILE="${CONF}"/mongos.conf
+export LOGS="${SNAP_COMMON}"/var/log/mongodb
 export LDAP_CONF_DIR="${SNAP_DATA}"/etc/ldap/
 
 if [ ! -f $MONGOS_CONFIG_FILE ]; then

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -3,11 +3,11 @@
 
 set -eux
 
-export CONF="${SNAP_DATA}"/etc/mongod
-export ETC="${SNAP_DATA}"/etc/
-export MONGOS_CONFIG_FILE="${CONF}"/mongos.conf
-export LOGS="${SNAP_COMMON}"/var/log/mongodb
-export LDAP_CONF_DIR="${SNAP_DATA}"/etc/ldap/
+export CONF="${SNAP_DATA}/etc/mongod"
+export ETC="${SNAP_DATA}/etc/"
+export MONGOS_CONFIG_FILE="${CONF}/mongos.conf"
+export LOGS="${SNAP_COMMON}/var/log/mongodb"
+export LDAP_CONF_DIR="${SNAP_DATA}/etc/ldap/"
 
 
 if [ ! -f $MONGOS_CONFIG_FILE ]; then
@@ -18,7 +18,7 @@ if [ ! -f $MONGOS_CONFIG_FILE ]; then
     # Grant permissions on $CONF
     chown root:snap_daemon $CONF
 
-    cp -r ${SNAP}/etc/mongod.conf ${MONGOS_CONFIG_FILE}
+    cp ${SNAP}/etc/mongod.conf ${MONGOS_CONFIG_FILE}
 
     # mongos.conf default values are not consistent with the snap directory system.
     yq -i ".processManagement.fork = false" ${MONGOS_CONFIG_FILE}

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pre-refresh hook for charmed-mongodb snap
+# post-refresh hook for charmed-mongodb snap
 
 set -eux
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -147,7 +147,6 @@ parts:
       - percona-backup-mongodb
       - util-linux
       - libldap-common
-      - curl
     stage-snaps:
       - yq
     override-prime: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,10 @@ system-usernames:
   snap_daemon: shared
 
 hooks:
+  post-refresh:
+    plugs:
+      - network
+      - network-bind
   install:
     plugs:
       - network
@@ -49,6 +53,9 @@ slots:
         - $SNAP_COMMON/var/log/mongodb
         - $SNAP_COMMON/var/log/mongos
         - $SNAP_COMMON/var/log/pbm
+
+environment:
+  LDAPCONF: $SNAP_DATA/etc/ldap/ldap.conf
 
 apps:
   mongosh:
@@ -140,6 +147,7 @@ parts:
       - percona-backup-mongodb
       - util-linux
       - libldap-common
+      - curl
     stage-snaps:
       - yq
     override-prime: |

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,6 +2,7 @@ import yaml
 import subprocess
 import time
 import pytest
+from pathlib import Path
 
 
 def test_install():
@@ -54,3 +55,39 @@ def test_all_services():
                 subprocess.run(f"sudo snap stop {snapcraft['name']}.{app}".split())
 
                 assert "active" in str(service.stdout)
+
+
+@pytest.mark.run(after="test_all_services")
+def test_remove():
+    with open("snap/snapcraft.yaml") as file:
+        snapcraft = yaml.safe_load(file)
+    subprocess.run(f"sudo snap remove --purge {snapcraft['name']}".split())
+
+
+@pytest.mark.run(after="test_remove")
+def test_refresh():
+    with open("snap/snapcraft.yaml") as file:
+        snapcraft = yaml.safe_load(file)
+
+    subprocess.run(f"sudo snap install --channel 6/edge {snapcraft['name']}".split())
+
+    subprocess.run(
+        f"sudo snap install ./{snapcraft['name']}_{snapcraft['version']}_amd64.snap --devmode".split(),
+        check=True,
+    )
+
+    mandatory_files = [
+        Path("/var/snap/charmed-mongodb/current/etc/mongod/mongod.conf"),
+        Path("/var/snap/charmed-mongodb/current/etc/mongod/mongos.conf"),
+        Path("/var/snap/charmed-mongodb/current/etc/ldap/ldap.conf"),
+    ]
+
+    for file_path in mandatory_files:
+        assert file_path.is_file()
+
+
+@pytest.mark.run(after="test_refresh")
+def test_final_remove():
+    with open("snap/snapcraft.yaml") as file:
+        snapcraft = yaml.safe_load(file)
+    subprocess.run(f"sudo snap remove --purge {snapcraft['name']}".split())


### PR DESCRIPTION
## Problem

LDAP + TLS needs to have a ldap configuration file accessible that defines among other things the TLS certificate file.
We install libldap-common as stage-package which means the ldap.conf is not in the expected list of possible paths (as seen [here](https://manpages.debian.org/jessie/libldap-2.4-2/ldap.conf.5.en.html).

## Solution

 * Copy the directory and set the correct permissions.
 * Add a post-refresh hook that does it as well if needed, and same for the mongos file that was added in a former PR.