### PR TITLE
fix: Bump DPW to have the build info

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,11 +9,11 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v41.0.0
   publish:
     name: Publish Snap
     needs: build
-    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v41.0.0
     with:
       channel: 8/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v40.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v41.0.0
   smoke:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
 * DPW 41 adds `SNAPCRAFT_BUILD_INFO: 1` to the snap build so that it embeds the security info.