### PR TITLE
feat(DPE-9339): Add vault & mongod-cli to snap

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -6,16 +6,21 @@ set -eux
 export ETC="$SNAP_DATA"/etc
 export CONF="${SNAP_DATA}"/etc/mongod
 export PBM_CONF="${SNAP_DATA}"/etc/pbm
+export VAULT_CONF="${SNAP_DATA}"/etc/vault
 export DATA="${SNAP_COMMON}"/var/lib/mongodb
 export LOGS="${SNAP_COMMON}"/var/log/mongodb
+export VAULT_LOGS="${SNAP_COMMON}"/var/log/vault
 export MONGO_CONFIG_FILE="${CONF}"/mongod.conf
 export MONGOS_CONFIG_FILE="${CONF}"/mongos.conf
+export VAULT_CONFIG_FILE="${VAULT_CONF}"/vault-agent.hcl
 
 # Create the necessary parent directories 
 mkdir -p $DATA
 mkdir -p $LOGS
+mkdir -p $VAULT_LOGS
 mkdir -p $PBM_CONF
 mkdir -p $CONF
+mkdir -p $VAULT_CONF
 
 # If we just created the directory, we set up permissions
 if [ stat -c '%u' "$DATA" == 0 ]; then
@@ -27,6 +32,11 @@ fi
 if [ stat -c '%u' "$LOGS" == 0 ]; then
     chmod -R 770 "${SNAP_COMMON}"
     chmod g+s "$LOGS"/*
+fi
+
+if [ stat -c '%u' "$VAULT_LOGS" == 0 ]; then
+    chmod -R 770 "${SNAP_COMMON}"
+    chmod g+s "$VAULT_LOGS"/*
 fi
 
 chown -R 584788:root "${SNAP_COMMON}"/*
@@ -41,7 +51,9 @@ echo "mongos configuration file does not exist."
 echo "copying default config to ${MONGOS_CONFIG_FILE}"
 cp -r ${SNAP}/etc/mongod.conf ${MONGOS_CONFIG_FILE}
 
-
+echo "vault configuration file does not exist."
+echo "copying default config to ${VAULT_CONFIG_FILE}"
+cp -r ${SNAP}/vault.hcl ${VAULT_CONFIG_FILE}
 
 # mongod.conf default values are not consistent with the snap directory system.
 yq -i ".processManagement.fork = false" ${MONGO_CONFIG_FILE}

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -60,3 +60,4 @@ if [ ! -d $VAULT_CONF ]; then
 
     # Change ownership of snap directories to allow snap_daemon to read/write
     chown -R 584788:root "${ETC}"
+fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -4,10 +4,13 @@
 set -eux
 
 export CONF="${SNAP_DATA}/etc/mongod"
+export VAULT_CONF="${SNAP_DATA}/etc/vault"
 export ETC="${SNAP_DATA}/etc/"
 export MONGOS_CONFIG_FILE="${CONF}/mongos.conf"
 export LOGS="${SNAP_COMMON}/var/log/mongodb"
+export VAULT_LOGS="${SNAP_COMMON}/var/log/vault"
 export LDAP_CONF_DIR="${SNAP_DATA}/etc/ldap/"
+export VAULT_CONFIG_FILE="${VAULT_CONF}/vault-agent.hcl"
 
 
 if [ ! -f $MONGOS_CONFIG_FILE ]; then
@@ -43,3 +46,17 @@ if  [ ! -d $LDAP_CONF_DIR ]; then
     # Change ownership of snap directories to allow snap_daemon to read/write
     chown -R 584788:root "${ETC}"
 fi
+
+if [ ! -d $VAULT_CONF ]; then
+    # Copy over the vault configuration
+    echo "vault configuration does not exist."
+    echo "copying default config to ${VAULT_CONF}."
+
+    # Grant enough permissions to create files
+    chown root:snap_daemon "$ETC"
+
+    mkdir -p $VAULT_CONF
+    cp -r "${SNAP}/vault.hcl" "${VAULT_CONFIG_FILE}"
+
+    # Change ownership of snap directories to allow snap_daemon to read/write
+    chown -R 584788:root "${ETC}"

--- a/snap/local/start-vault-agent.sh
+++ b/snap/local/start-vault-agent.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+ulimit -SHf unlimited
+ulimit -SHt unlimited
+ulimit -SHv unlimited
+ulimit -SHm unlimited
+ulimit -Sl unlimited
+ulimit -SHn 64000
+ulimit -SHu 64000
+
+# For security measures, daemons should not be run as sudo. Execute vault as the non-sudo user: snap-daemon.
+exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
+  --regid snap_daemon -- $SNAP/bin/vault agent -config ${SNAP_DATA}/etc/vault/agent-config.hcl "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -95,6 +95,13 @@ apps:
     plugs:
       - network
       - network-bind
+  mongod-cli:
+    command: drop_priv.sh mongod
+    plugs:
+      - network
+      - network-bind
+    slots:
+      - logs
   mongoexport:
     command: drop_priv.sh mongoexport
   mongofiles:
@@ -153,7 +160,15 @@ apps:
       - network-bind
     slots:
       - logs
-
+  vault-agent:
+    daemon: simple
+    install-mode: disable
+    command: start-vault-agent.sh
+    plugs:
+      - network
+      - network-bind
+    slots:
+      - logs
 parts:
   mongo-deb:
     plugin: nil
@@ -168,6 +183,7 @@ parts:
       - mongodb-shell
     stage-snaps:
       - yq
+      - vault
     override-prime: |
       craftctl default
       LICENSE_LOC=usr/share/doc/percona-server-mongodb
@@ -178,7 +194,7 @@ parts:
         licenses/LICENSE-percona-backup-mongodb
       usr/share/doc/mongodb-exporter/copyright:
         licenses/LICENSE-mongodb-exporter
-      usr/share/doc/mongodh-shell/copyright:
+      usr/share/doc/mongodb-shell/copyright:
         licenses/LICENSE-mongodb-shell
   wrapper:
     plugin: dump

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -80,6 +80,7 @@ def test_refresh():
         Path("/var/snap/charmed-mongodb/current/etc/mongod/mongod.conf"),
         Path("/var/snap/charmed-mongodb/current/etc/mongod/mongos.conf"),
         Path("/var/snap/charmed-mongodb/current/etc/ldap/ldap.conf"),
+        Path("/var/snap/charmed-mongodb/current/etc/vault/vault.hcl"),
     ]
 
     for file_path in mandatory_files:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -80,10 +80,11 @@ def test_refresh():
         Path("/var/snap/charmed-mongodb/current/etc/mongod/mongod.conf"),
         Path("/var/snap/charmed-mongodb/current/etc/mongod/mongos.conf"),
         Path("/var/snap/charmed-mongodb/current/etc/ldap/ldap.conf"),
-        Path("/var/snap/charmed-mongodb/current/etc/vault/vault.hcl"),
+        Path("/var/snap/charmed-mongodb/current/etc/vault/vault-agent.hcl"),
     ]
 
     for file_path in mandatory_files:
+        breakpoint()
         assert file_path.is_file()
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -84,7 +84,6 @@ def test_refresh():
     ]
 
     for file_path in mandatory_files:
-        breakpoint()
         assert file_path.is_file()
 
 


### PR DESCRIPTION
 * Add vault from the snap + script to run it as agent.
 * Hooks on install & post-refresh
 * Add mongod as a cli for the key rotation calls
 * Update the smoke test to check for vault.hcl configuration file
 * Fix typo in the layout for licenses