### PR TITLE
fix: test-home-plug

### DIFF
--- a/snap/local/start-vault-agent.sh
+++ b/snap/local/start-vault-agent.sh
@@ -10,4 +10,4 @@ ulimit -SHu 64000
 
 # For security measures, daemons should not be run as sudo. Execute vault as the non-sudo user: snap-daemon.
 exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon \
-  --regid snap_daemon -- $SNAP/bin/vault agent -config ${SNAP_DATA}/etc/vault/agent-config.hcl "$@"
+  --regid snap_daemon --reset-env -- $SNAP/bin/vault agent -config ${SNAP_DATA}/etc/vault/agent-config.hcl "$@"


### PR DESCRIPTION
Vault needs to access the home directory of the user that runs the process (it looks for `~/.vault`).
Using `setpriv` without `--reset-env` keeps the `$HOME` from root, to which it can't write.

Adding that parameter fixes that issue.