### PR TITLE
feat(DPE-9598): SSL_CERT_DIR for backups

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -147,6 +147,8 @@ apps:
     plugs:
       - network
       - network-bind
+    environment:
+      SSL_CERT_DIR: "/etc/ssl/certs:/etc/pki/tls/certs:$SNAP/etc/ssl/certs:$SNAP_DATA/etc/pbm/certs"
   pbm-agent:
     daemon: simple
     install-mode: disable
@@ -160,6 +162,9 @@ apps:
       - network-bind
     slots:
       - logs
+    environment:
+      # Base from UBUNTU + RHEL, then snap certs, then local certs
+      SSL_CERT_DIR: "/etc/ssl/certs:/etc/pki/tls/certs:$SNAP/etc/ssl/certs:$SNAP_DATA/etc/pbm/certs"
   vault-agent:
     daemon: simple
     install-mode: disable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -148,7 +148,11 @@ apps:
       - network
       - network-bind
     environment:
-      SSL_CERT_DIR: "/etc/ssl/certs:/etc/pki/tls/certs:$SNAP/etc/ssl/certs:$SNAP_DATA/etc/pbm/certs"
+      SSL_CERT_DIR: >
+        /etc/ssl/certs:
+        /etc/pki/tls/certs:
+        $SNAP/etc/ssl/certs:
+        $SNAP_DATA/etc/pbm/certs
   pbm-agent:
     daemon: simple
     install-mode: disable
@@ -164,7 +168,11 @@ apps:
       - logs
     environment:
       # Base from UBUNTU + RHEL, then snap certs, then local certs
-      SSL_CERT_DIR: "/etc/ssl/certs:/etc/pki/tls/certs:$SNAP/etc/ssl/certs:$SNAP_DATA/etc/pbm/certs"
+      SSL_CERT_DIR: >
+        /etc/ssl/certs:
+        /etc/pki/tls/certs:
+        $SNAP/etc/ssl/certs:
+        $SNAP_DATA/etc/pbm/certs
   vault-agent:
     daemon: simple
     install-mode: disable


### PR DESCRIPTION
Goes along with [this PR](https://github.com/canonical/charmed-mongodb-rock/pull/69)
This is the backup rework.