### PR TITLE
feat: Bump to 8.0.10-4

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -7,3 +7,4 @@ jobs:
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v2
+    permissions: {}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,8 +15,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install tox
         run: python3 -m pip install tox
       - name: YAML Lint
         run: tox run -e lint
+    permissions:
+      contents: read

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v41.0.0
+    permissions:
+      actions: read # Needed for GitHub API call to get workflow version
+      contents: read
   publish:
     name: Publish Snap
     needs: build
@@ -20,4 +23,5 @@ jobs:
     secrets:
       snap-store-token: ${{ secrets.STORE_LOGIN }}
     permissions:
+      actions: read # Needed for GitHub API call to get workflow version
       contents: write

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -13,18 +13,23 @@ jobs:
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v41.0.0
+    permissions:
+      actions: read # Needed for GitHub API call to get workflow version
+      contents: read
   smoke:
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install tox
         run: python3 -m pip install tox
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
       - name: Smoke Tests
         run: tox run -e smoke
+    permissions:
+      contents: read

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-mongodb
 base: core24 # the base snap is the execution environment for this snap
-version: "8.0.10-3" # just for humans, typically '1.2+git' or '1.3.2'
+version: "8.0.10-4" # just for humans, typically '1.2+git' or '1.3.2'
 summary: MongoDB in a snap. # 79 char long summary
 description: |
   MongoDB is a source-available cross-platform


### PR DESCRIPTION
Fixes a bunch of upstream CVEs: 
 * CVE-2026-8053
 * CVE-2026-8199
 * CVE-2026-8336
 * CVE-2026-8202
 * CVE-2026-8200
* Bump Mongo Tools to 100.17.0